### PR TITLE
Add support sublime context menu and file syntax option for Python3

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,92 @@
+[
+    {
+        "caption": "Preferences",
+        "id": "preferences",
+        "mnemonic": "n",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "id": "package-settings",
+                "mnemonic": "P",
+                "children":
+                [
+                    {
+                        "caption": "QuickSimplenote",
+                        "children":
+                        [
+                            {
+                                "args": {
+                                    "file": "${packages}/QuickSimplenote/README.md"
+                                },
+                                "caption": "README",
+                                "command": "open_file"
+                            },
+                            { "caption": "-" },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/QuickSimplenote/quick_simplenote.sublime-settings"},
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/quick_simplenote.sublime-settings"},
+                                "caption": "Settings – User"
+                            },
+                            { "caption": "-" },
+                            {
+                                "args": {
+                                    "file": "${packages}/QuickSimplenote/Default (Windows).sublime-keymap",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Key Bindings \u2013 Default",
+                                "command": "open_file"
+                            },
+                            {
+                                "args": {
+                                    "file": "${packages}/QuickSimplenote/Default (OSX).sublime-keymap",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Key Bindings \u2013 Default",
+                                "command": "open_file"
+                            },
+                            {
+                                "args": {
+                                    "file": "${packages}/QuickSimplenote/Default (Linux).sublime-keymap",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Key Bindings \u2013 Default",
+                                "command": "open_file"
+                            },
+                            {
+                                "args": {
+                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Key Bindings \u2013 User",
+                                "command": "open_file"
+                            },
+                            {
+                                "args": {
+                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Key Bindings \u2013 User",
+                                "command": "open_file"
+                            },
+                            {
+                                "args": {
+                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Key Bindings \u2013 User",
+                                "command": "open_file"
+                            },
+                            { "caption": "-" }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/quick_simplenote.py
+++ b/quick_simplenote.py
@@ -104,7 +104,7 @@ def get_note_from_path(view_filepath):
             if note:
                 note = note[0]
 
-    
+
     return note
 
 def get_note_name(note):
@@ -293,6 +293,13 @@ class HandleNoteViewCommand(sublime_plugin.EventListener):
                 HandleNoteViewCommand.waiting_to_save.append(new_entry)
             sublime.set_timeout(flush_saves, debounce_time)
 
+    def on_load(self, view):
+        view_filepath = view.file_name()
+        note = get_note_from_path(view_filepath)
+        syntax = settings.get('note_syntax')
+        if note and syntax:
+           view.set_syntax_file(syntax)
+
     def get_current_content(self, view):
         return view.substr(sublime.Region(0, view.size()))
 
@@ -426,7 +433,7 @@ class StartQuickSimplenoteSyncCommand(sublime_plugin.ApplicationCommand):
             for view in view_list:
                 if view.file_name() == None:
                     continue
-                
+
                 if view.is_dirty():
                     open_files_dirty.append(path.split(view.file_name())[1])
                 else:
@@ -440,13 +447,13 @@ class StartQuickSimplenoteSyncCommand(sublime_plugin.ApplicationCommand):
 
             if not note['needs_update']:
                 continue
-            
+
             try:
                 filename = note['filename']
             except KeyError as e:
                 others.append(note)
                 continue
-            
+
             if filename in open_files_dirty:
                 lu.append(note)
             elif filename in open_files_ok:

--- a/quick_simplenote.sublime-settings
+++ b/quick_simplenote.sublime-settings
@@ -5,6 +5,13 @@
 	"username": ""
     ,"password": ""
     // --------------------------------
+    // Simplenote Synctax setting:
+    // (If you are using MarkdownEditing, try
+    //  "note_syntax": "Packages/MarkdownEditing/Markdown.tmLanguage"
+    // )
+    // --------------------------------
+    ,"note_syntax": ""
+    // --------------------------------
     // Sync settings:
     // --------------------------------
     // Sync when sublime text starts:
@@ -32,5 +39,5 @@
     	// "title_regex": "\\[ST\\]",
     	// "extension": "todo"
     // }]
-    
+
 }


### PR DESCRIPTION
The same as above, but for python3